### PR TITLE
fix test invocation with py-test

### DIFF
--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -10,11 +10,11 @@ from dockerpycreds import (
 
 
 class TestStore(object):
-    def teardown_method(self):
+    def teardown_method(self, method):
         for server in self.tmp_keys:
             self.store.erase(server)
 
-    def setup_method(self):
+    def setup_method(self, method):
         self.tmp_keys = []
         if sys.platform.startswith('linux'):
             self.store = Store(DEFAULT_LINUX_STORE)


### PR DESCRIPTION
before:

```
E           TypeError: setup_method() takes exactly 1 argument (2 given)
```

after:

```
tests/store_test.py FE.EFEFE
```

http://doc.pytest.org/en/latest/xunit_setup.html#method-and-function-level-setup-teardown

`./setup.py test` still gives me

```
Ran 0 tests in 0.000s
```

Not sure how you're running the test suite; it would also be very nice if you could mock outputs of `docker-credential-secretservice` so we don't have to have it present on a system.
