### PR TITLE
Drop support for EOL Python 2.6 and 3.3

### DIFF
--- a/dockerpycreds/errors.py
+++ b/dockerpycreds/errors.py
@@ -14,12 +14,12 @@ def process_store_error(cpe, program):
     message = cpe.output.decode('utf-8')
     if 'credentials not found in native keychain' in message:
         return CredentialsNotFound(
-            'No matching credentials in {0}'.format(
+            'No matching credentials in {}'.format(
                 program
             )
         )
     return StoreError(
-        'Credentials store {0} exited with "{1}".'.format(
+        'Credentials store {} exited with "{}".'.format(
             program, cpe.output.decode('utf-8').strip()
         )
     )

--- a/dockerpycreds/store.py
+++ b/dockerpycreds/store.py
@@ -21,7 +21,7 @@ class Store(object):
         self.environment = environment
         if self.exe is None:
             raise errors.InitializationError(
-                '{0} not installed or not available in PATH'.format(
+                '{} not installed or not available in PATH'.format(
                     self.program
                 )
             )
@@ -88,13 +88,13 @@ class Store(object):
         except OSError as e:
             if e.errno == os.errno.ENOENT:
                 raise errors.StoreError(
-                    '{0} not installed or not available in PATH'.format(
+                    '{} not installed or not available in PATH'.format(
                         self.program
                     )
                 )
             else:
                 raise errors.StoreError(
-                    'Unexpected OS error "{0}", errno={1}'.format(
+                    'Unexpected OS error "{}", errno={}'.format(
                         e.strerror, e.errno
                     )
                 )

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ setup(
     tests_require=test_requirements,
     zip_safe=False,
     test_suite='tests',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Other Environment',
@@ -38,10 +40,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/store_test.py
+++ b/tests/store_test.py
@@ -33,7 +33,7 @@ class TestStore(object):
             self.store = Store(DEFAULT_OSX_STORE)
 
     def get_random_servername(self):
-        res = 'pycreds_test_{0:x}'.format(random.getrandbits(32))
+        res = 'pycreds_test_{:x}'.format(random.getrandbits(32))
         self.tmp_keys.append(res)
         return res
 


### PR DESCRIPTION

Python 2.6 and 3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.6 | 2008-10-01 | 2013-10-29
3.3 | 2012-09-29 | 2017-09-29

They're also relatively little used. Here are the downloads from PyPI for docker-pycreds for last month:

 category | percent | downloads |
|----------|--------:|----------:|
|      2.7 |  66.44% | 1,480,078 |
|      3.6 |  22.85% |   509,075 |
|      3.5 |   7.16% |   159,472 |
|      3.7 |   1.69% |    37,606 |
|      3.4 |   1.30% |    28,911 |
| null     |   0.43% |     9,538 |
|      2.6 |   0.12% |     2,683 |
|      3.8 |   0.01% |       118 |
|      3.3 |   0.00% |        65 |
|      3.2 |   0.00% |         2 |
| Total    |         | 2,227,548 |
