### PR TITLE
Dockerfile: switch to alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN gpg2 --import-ownertrust gpg-keys/ownertrust
 RUN yes | pass init $(gpg2 --no-auto-check-trustdb --list-secret-key | awk '/^sec/{getline; $1=$1; print}')
 RUN gpg2 --check-trustdb
 
-ARG VERSION=v0.6.0
+ARG CREDSTORE_VERSION=v0.6.0
 RUN curl -sSL -o /opt/docker-credential-pass.tar.gz \
-    https://github.com/docker/docker-credential-helpers/releases/download/$VERSION/docker-credential-pass-$VERSION-amd64.tar.gz && \
+    https://github.com/docker/docker-credential-helpers/releases/download/${CREDSTORE_VERSION}/docker-credential-pass-${CREDSTORE_VERSION}-amd64.tar.gz && \
     tar -xf /opt/docker-credential-pass.tar.gz -O > /usr/local/bin/docker-credential-pass && \
     rm -rf /opt/docker-credential-pass.tar.gz && \
     chmod +x /usr/local/bin/docker-credential-pass

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN gpg2 --import-ownertrust gpg-keys/ownertrust
 RUN yes | pass init $(gpg2 --no-auto-check-trustdb --list-secret-key | awk '/^sec/{getline; $1=$1; print}')
 RUN gpg2 --check-trustdb
 
-ARG CREDSTORE_VERSION=v0.6.0
+ARG CREDSTORE_VERSION=v0.6.3
 RUN curl -sSL -o /opt/docker-credential-pass.tar.gz \
     https://github.com/docker/docker-credential-helpers/releases/download/${CREDSTORE_VERSION}/docker-credential-pass-${CREDSTORE_VERSION}-amd64.tar.gz && \
     tar -xf /opt/docker-credential-pass.tar.gz -O > /usr/local/bin/docker-credential-pass && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN pip install -r test-requirements.txt
 
 COPY . /src
 RUN python setup.py develop
-CMD pytest -v ./tests
+CMD ["pytest", "-v", "./tests"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.6.4
+ARG PYTHON_VERSION=3.7
+
+FROM python:${PYTHON_VERSION}
 RUN apt-get update && apt-get -y install \
     gnupg2 \
     pass \
@@ -7,7 +9,9 @@ RUN apt-get update && apt-get -y install \
 COPY ./tests/gpg-keys /gpg-keys
 RUN gpg2 --import gpg-keys/secret
 RUN gpg2 --import-ownertrust gpg-keys/ownertrust
-RUN yes | pass init $(gpg2 --no-auto-check-trustdb --list-secret-keys | grep ^sec | cut -d/ -f2 | cut -d" " -f1)
+RUN yes | pass init $(gpg2 --no-auto-check-trustdb --list-secret-key | awk '/^sec/{getline; $1=$1; print}')
+RUN gpg2 --check-trustdb
+
 ARG VERSION=v0.6.0
 RUN curl -sSL -o /opt/docker-credential-pass.tar.gz \
     https://github.com/docker/docker-credential-helpers/releases/download/$VERSION/docker-credential-pass-$VERSION-amd64.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 ARG PYTHON_VERSION=3.7
 
-FROM python:${PYTHON_VERSION}
-RUN apt-get update && apt-get -y install \
-    gnupg2 \
-    pass \
+FROM python:${PYTHON_VERSION}-alpine
+RUN apk add --no-cache \
+    coreutils \
+    gnupg \
     curl
+
+# TODO remove once pass is in the main repository
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing pass
 
 COPY ./tests/gpg-keys /gpg-keys
 RUN gpg2 --import gpg-keys/secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,14 @@ RUN curl -sSL -o /opt/docker-credential-pass.tar.gz \
     tar -xf /opt/docker-credential-pass.tar.gz -O > /usr/local/bin/docker-credential-pass && \
     rm -rf /opt/docker-credential-pass.tar.gz && \
     chmod +x /usr/local/bin/docker-credential-pass
-COPY . /src
 WORKDIR /src
-RUN python setup.py develop && pip install -r test-requirements.txt
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY test-requirements.txt .
+RUN pip install -r test-requirements.txt
+
+COPY . /src
+RUN python setup.py develop
 CMD pytest -v ./tests


### PR DESCRIPTION
follow-up to https://github.com/shin-/dockerpy-creds/pull/11, but the `pass` package is not yet in the "stable" Alpine package index, so perhaps you didn't want that.

The alpine image makes the image quite a bit smaller;

    REPOSITORY            TAG       IMAGE ID        CREATED             SIZE
    docker/pycreds-test   alpine    2451e1c13a9e    3 seconds ago       134MB
    docker/pycreds-test   latest    70526611619f    10 minutes ago      951MB
